### PR TITLE
improving normalization of luminance values when creating a calibration

### DIFF
--- a/psychopy_pixx/devices/viewpixx.py
+++ b/psychopy_pixx/devices/viewpixx.py
@@ -226,7 +226,10 @@ def interp_clut(monitor, gamma):
         raise ValueError(f"Expects matching levels and luminances,\n"
                          f"got {levels.shape} != {lums.shape}.")
     
-    lums = (lums - lums[:, [0]]) / (lums[:, [-1]] - lums[:, [0]] + 1e-8)
+    lums_normalized = []
+    for l in lums:
+        lums_normalized.append(np.interp(l, (l.min(), l.max()), (0, 1)))
+    lums = np.asarray(lums_normalized)
     
     is_lum_incr = np.all(np.diff(lums) >= 0, axis=0)  # all guns have to be increasing
     if not np.all(is_lum_incr):


### PR DESCRIPTION
With this pull request, I just want to fix a small bug. The used code to normalize the lums values 
```python
lums = (lums - lums[:, [0]]) / (lums[:, [-1]] - lums[:, [0]] + 1e-8)
```
is normalizing the lums values on the base of the first and the last value. This can, but don't have to be the max and min values. The code in this pull request aims to improve the normalization process by utilizing the np.interp() function oriented on the min and max values of the respective lum array.